### PR TITLE
rstanarm

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -151,6 +151,7 @@ These packages help you build models and make inferences. Often the same package
 * [h2o](http://www.h2o.ai/) - parallel distributed machine learning algorithms
 * [ROCR](http://rocr.bioinf.mpi-sb.mpg.de/) - plots to visualize classifier performance
 * [pROC](http://web.expasy.org/pROC/) - Tools for visualizing, smoothing and comparing ROC curves
+* [rstanarm](http://mc-stan.org/interfaces/rstanarm.html) - Bayesian Applied Regression Modeling via Stan
 
 
 ## Communicate


### PR DESCRIPTION
Suggesting [rstanarm](http://mc-stan.org/interfaces/rstanarm.html). 

Meets all requirements: Website, excellent vignettes, unit tests, open development, intuitive interface (fit models by adding "stan_" to usual R regression models). It is rather new though (January 2016).
